### PR TITLE
feat: vendor portal with magic-link auth and weekly highlights

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,0 +1,3 @@
+4.1.0 — Vendor Portal Integration & Weekly Highlights
+- Added vendor magic-link authentication and portal dashboard.
+- Introduced `gffm_highlight` CPT and `[gffm_this_week]` shortcode.

--- a/TESTPLAN.md
+++ b/TESTPLAN.md
@@ -1,0 +1,13 @@
+# Test Plan
+
+1. Activate the plugin and ensure no fatal errors.
+2. Verify the `gffm_vendor` role exists after activation.
+3. Edit a Vendor post:
+   - Use the **Vendor Portal Access** meta box to enable access.
+   - Send an invite email and confirm a user is created and linked.
+4. Follow the magic link to `/vendor-portal/` and log in as the vendor.
+5. In the portal:
+   - Update profile fields and confirm post meta saves.
+   - Submit a weekly highlight and ensure only one post per week.
+6. Place `[gffm_this_week]` on a page and confirm highlights appear.
+7. Uninstall plugin and confirm portal options are removed but posts remain.

--- a/assets/portal.css
+++ b/assets/portal.css
@@ -1,0 +1,10 @@
+.gffm-portal-tabs{max-width:600px;margin:0 auto}
+.gffm-tab-nav{display:flex;list-style:none;padding:0;margin:0 0 1em;border-bottom:1px solid #ccc}
+.gffm-tab-nav li{margin-right:1em;padding:0.5em 1em;cursor:pointer}
+.gffm-tab-nav li.active{border-bottom:2px solid #000}
+.gffm-tab-content{display:none}
+.gffm-tab-content.active{display:block}
+.gffm-highlight-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:16px}
+.gffm-highlight-card{border:1px solid #eee;padding:10px;background:#fff}
+.gffm-notice{margin:1em 0;padding:0.5em;background:#e6ffed;border-left:4px solid #46b450}
+.gffm-img-preview img{max-width:100%;height:auto;display:block;margin-bottom:4px}

--- a/assets/portal.js
+++ b/assets/portal.js
@@ -1,0 +1,21 @@
+(function($){
+  $(document).on('click','.gffm-tab-nav li',function(){
+    var tab = $(this).data('tab');
+    $('.gffm-tab-nav li').removeClass('active');
+    $(this).addClass('active');
+    $('.gffm-tab-content').removeClass('active');
+    $('#gffm-tab-'+tab).addClass('active');
+  });
+  $(document).on('click','.gffm-img-btn',function(e){
+    e.preventDefault();
+    var target = $(this).data('target');
+    var field = $('[name="'+target+'"]');
+    var frame = wp.media({title:'Select Image',multiple:false});
+    frame.on('select',function(){
+      var attachment = frame.state().get('selection').first().toJSON();
+      field.val(attachment.id);
+      field.siblings('.gffm-img-preview').html('<img src="'+attachment.url+'" />');
+    });
+    frame.open();
+  });
+})(jQuery);

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,5 @@
+# Decisions
+
+- Magic link authentication selected with HMAC tokens expiring after 24 hours.
+- Profile editing writes directly to Smart Custom Fields post meta to maintain compatibility.
+- Weekly highlights grouped by configurable week start day (default Saturday).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,3 @@
+# Roadmap
+
+- Future vendor portal panels for invoices, documents, and additional resources.

--- a/gffm-market-manager-unified.php
+++ b/gffm-market-manager-unified.php
@@ -15,26 +15,33 @@ define('GFFM_VERSION','4.1.1');
 define('GFFM_DIR', plugin_dir_path(__FILE__));
 define('GFFM_URL', plugin_dir_url(__FILE__));
 
-$gffm_includes = array(
-  'class-gffm-roles.php',
-  'class-gffm-post-types.php',
-  'class-gffm-settings.php',
-  'class-gffm-admin.php',
-  'class-gffm-enrollment.php',
-  'class-gffm-waitlist.php',
-  'class-gffm-export.php',
-  'class-gffm-invoices.php',
-  'class-gffm-cron.php',
-  'class-gffm-rest.php',
-  'class-gffm-vendor-users.php',
-  'class-gffm-highlights.php',
-  'class-gffm-portal.php',
-);
+require_once GFFM_DIR . 'includes/class-gffm-roles.php';
+require_once GFFM_DIR . 'includes/class-gffm-post-types.php';
+require_once GFFM_DIR . 'includes/class-gffm-settings.php';
+require_once GFFM_DIR . 'includes/class-gffm-admin.php';
+require_once GFFM_DIR . 'includes/class-gffm-enrollment.php';
+require_once GFFM_DIR . 'includes/class-gffm-waitlist.php';
+require_once GFFM_DIR . 'includes/class-gffm-export.php';
+require_once GFFM_DIR . 'includes/class-gffm-invoices.php';
+require_once GFFM_DIR . 'includes/class-gffm-cron.php';
+require_once GFFM_DIR . 'includes/class-gffm-rest.php';
 
-foreach( $gffm_includes as $file ) { $path = GFFM_DIR . 'includes/' . $file; if( file_exists($path) ) require_once $path; }
+// New Vendor Portal integration
+require_once GFFM_DIR . 'includes/helpers/class-gffm-util.php';
+require_once GFFM_DIR . 'includes/portal/class-gffm-magic.php';
+require_once GFFM_DIR . 'includes/portal/class-gffm-vendor-link.php';
+require_once GFFM_DIR . 'includes/portal/class-gffm-portal.php';
+require_once GFFM_DIR . 'includes/highlights/class-gffm-highlights.php';
 
 register_activation_hook(__FILE__, function(){
-    if ( class_exists('GFFM_Roles') ) { GFFM_Roles::add_roles(); }
+    if ( class_exists('GFFM_Roles') ) {
+        GFFM_Roles::add_roles();
+        if ( method_exists('GFFM_Roles', 'ensure_vendor_role') ) {
+            GFFM_Roles::ensure_vendor_role();
+        }
+    } else {
+        add_role('gffm_vendor', 'Vendor', ['read'=>true,'upload_files'=>true]);
+    }
     if ( class_exists('GFFM_Post_Types') ) { GFFM_Post_Types::init(); flush_rewrite_rules(); }
 });
 

--- a/includes/class-gffm-roles.php
+++ b/includes/class-gffm-roles.php
@@ -9,10 +9,21 @@ class GFFM_Roles {
             'edit_posts' => false,
         ]);
 
+        self::ensure_vendor_role();
+
         // map caps to admin too
         $admin = get_role('administrator');
         if($admin && !$admin->has_cap('gffm_manage')){
             $admin->add_cap('gffm_manage');
+        }
+    }
+
+    public static function ensure_vendor_role(){
+        if( ! get_role('gffm_vendor') ){
+            add_role('gffm_vendor', __('Vendor','gffm'), [
+                'read' => true,
+                'upload_files' => true,
+            ]);
         }
     }
 }

--- a/includes/class-gffm-settings.php
+++ b/includes/class-gffm-settings.php
@@ -49,6 +49,7 @@ class GFFM_Settings {
         echo '<div class="gffm-admin-h"><img class="gffm-logo" src="'.esc_url(GFFM_URL.'assets/logo.png').'" alt="logo"/><h1>'.esc_html__('Market Manager','gffm').'</h1></div>';
         echo '<div class="gffm-cards">';
         echo '<a class="gffm-card" href="'.admin_url('admin.php?page=gffm_settings').'"><h3>'.esc_html__('Settings','gffm').'</h3><p>'.esc_html__('Configure emails, vendors mode, capacity, and more.','gffm').'</p></a>';
+        echo '<a class="gffm-card" href="'.admin_url('admin.php?page=gffm_vendor_portal').'"><h3>'.esc_html__('Vendor Portal','gffm').'</h3><p>'.esc_html__('Manage portal week start, profile fields, and invite templates.','gffm').'</p></a>';
         echo '<a class="gffm-card" href="'.admin_url('admin.php?page=gffm_assignment').'"><h3>'.esc_html__('Vendor Assignment','gffm').'</h3><p>'.esc_html__('Link existing vendor records or enable them for this system.','gffm').'</p></a>';
         echo '<a class="gffm-card" href="'.admin_url('admin.php?page=gffm_export').'"><h3>'.esc_html__('Export / Import','gffm').'</h3><p>'.esc_html__('Backup or migrate your data (CSV/JSON).','gffm').'</p></a>';
         echo '<a class="gffm-card" href="'.admin_url('edit.php?post_type=gffm_enrollment').'"><h3>'.esc_html__('Enrollments','gffm').'</h3><p>'.esc_html__('View & manage vendor signups and waitlist.','gffm').'</p></a>';

--- a/includes/helpers/class-gffm-util.php
+++ b/includes/helpers/class-gffm-util.php
@@ -1,0 +1,37 @@
+<?php
+defined('ABSPATH') || exit;
+
+class GFFM_Util {
+  public static function week_start_day(): string {
+    $opt = get_option('gffm_week_start_day', 'saturday');
+    $valid = ['monday','tuesday','wednesday','thursday','friday','saturday','sunday'];
+    return in_array(strtolower($opt), $valid, true) ? strtolower($opt) : 'saturday';
+  }
+
+  public static function week_key(?string $date = null): string {
+    $ts = $date ? strtotime($date) : current_time('timestamp');
+    $start = self::shift_to_week_start($ts, self::week_start_day());
+    return wp_date('Y-\\WW', $start);
+  }
+
+  private static function shift_to_week_start(int $ts, string $startDay): int {
+    $map = ['sunday'=>0,'monday'=>1,'tuesday'=>2,'wednesday'=>3,'thursday'=>4,'friday'=>5,'saturday'=>6];
+    $target = $map[$startDay] ?? 6;
+    $current = (int) wp_date('w', $ts);
+    $diff = $current - $target;
+    if ($diff < 0) { $diff += 7; }
+    return strtotime("-{$diff} days", $ts);
+  }
+
+  public static function current_user_vendor_id(): int {
+    $uid = get_current_user_id();
+    return (int) get_user_meta($uid, '_gffm_vendor_id', true);
+  }
+
+  public static function can_edit_vendor(int $vendor_id, int $user_id = 0): bool {
+    $user_id = $user_id ?: get_current_user_id();
+    if (user_can($user_id, 'manage_options') || user_can($user_id, 'gffm_manage')) return true;
+    $linked = (int) get_user_meta($user_id, '_gffm_vendor_id', true);
+    return $linked && $linked === (int)$vendor_id;
+  }
+}

--- a/includes/highlights/class-gffm-highlights.php
+++ b/includes/highlights/class-gffm-highlights.php
@@ -1,0 +1,54 @@
+<?php
+defined('ABSPATH') || exit;
+
+class GFFM_Highlights {
+  public static function init() {
+    add_action('init', [__CLASS__, 'register']);
+    add_action('save_post_gffm_highlight', [__CLASS__, 'save_week_key'], 10, 3);
+    add_shortcode('gffm_this_week', [__CLASS__, 'shortcode']);
+  }
+
+  public static function register() {
+    register_post_type('gffm_highlight', [
+      'label' => __('Weekly Highlights','gffm'),
+      'public' => true,
+      'show_in_rest' => true,
+      'supports' => ['title','editor','thumbnail','author'],
+    ]);
+  }
+
+  public static function save_week_key($post_id, $post, $update) {
+    if ( wp_is_post_autosave($post_id) || wp_is_post_revision($post_id) ) return;
+    $week = GFFM_Util::week_key($post->post_date);
+    update_post_meta($post_id, '_gffm_week_key', $week);
+  }
+
+  public static function shortcode($atts) {
+    $atts = shortcode_atts(['date' => ''], $atts, 'gffm_this_week');
+    $date = $atts['date'] ? sanitize_text_field($atts['date']) : null;
+    $week_key = GFFM_Util::week_key($date);
+    $posts = get_posts([
+      'post_type' => 'gffm_highlight',
+      'post_status' => 'publish',
+      'meta_key' => '_gffm_week_key',
+      'meta_value' => $week_key,
+      'posts_per_page' => -1,
+    ]);
+    if ( ! $posts ) {
+      return '<p>'.esc_html__('No highlights this week.','gffm').'</p>';
+    }
+    $out = '<div class="gffm-highlight-grid">';
+    foreach ( $posts as $p ) {
+      $out .= '<div class="gffm-highlight-card">';
+      if ( has_post_thumbnail($p) ) {
+        $out .= get_the_post_thumbnail($p, 'medium');
+      }
+      $out .= '<h3>'.esc_html(get_the_title($p)).'</h3>';
+      $out .= '<div class="gffm-highlight-content">'.wp_kses_post(wpautop($p->post_content)).'</div>';
+      $out .= '</div>';
+    }
+    $out .= '</div>';
+    return $out;
+  }
+}
+GFFM_Highlights::init();

--- a/includes/portal/class-gffm-magic.php
+++ b/includes/portal/class-gffm-magic.php
@@ -1,0 +1,34 @@
+<?php
+defined('ABSPATH') || exit;
+
+class GFFM_Magic {
+  public static function issue_token(int $user_id, int $ttl = 86400): string {
+    $exp = time() + max(60, $ttl);
+    $data = $user_id . '|' . $exp;
+    $sig  = hash_hmac('sha256', $data, wp_salt('auth'));
+    return base64_encode($data . '|' . $sig);
+  }
+
+  public static function parse_token(string $token) {
+    $raw = base64_decode($token, true);
+    if (!$raw) return false;
+    $parts = explode('|', $raw);
+    if (count($parts) !== 3) return false;
+    [$uid, $exp, $sig] = $parts;
+    $calc = hash_hmac('sha256', $uid . '|' . $exp, wp_salt('auth'));
+    if (!hash_equals($calc, $sig)) return false;
+    if (time() > (int) $exp) return false;
+    return (int) $uid;
+  }
+
+  public static function route() {
+    if (!isset($_GET['gffm_magic'])) return;
+    $uid = self::parse_token(sanitize_text_field(wp_unslash($_GET['gffm_magic'])));
+    if ($uid) {
+      wp_set_auth_cookie($uid, true);
+      wp_safe_redirect(home_url('/vendor-portal/'));
+      exit;
+    }
+  }
+}
+add_action('init', ['GFFM_Magic','route']);

--- a/includes/portal/class-gffm-portal.php
+++ b/includes/portal/class-gffm-portal.php
@@ -1,0 +1,217 @@
+<?php
+defined('ABSPATH') || exit;
+
+class GFFM_Portal {
+  public static function init() {
+    add_shortcode('gffm_portal', [__CLASS__, 'shortcode']);
+    add_action('admin_menu', [__CLASS__, 'menu']);
+    add_action('admin_init', [__CLASS__, 'register_settings']);
+  }
+
+  public static function default_mapping(): string {
+    return json_encode([
+      'vendor_phone' => ['label'=>'Phone','type'=>'text'],
+      'vendor_description' => ['label'=>'About','type'=>'textarea'],
+      'vendor_website' => ['label'=>'Website','type'=>'url'],
+      'vendor_facebook' => ['label'=>'Facebook','type'=>'url'],
+      'vendor_instagram' => ['label'=>'Instagram','type'=>'url'],
+      'vendor_logo' => ['label'=>'Logo','type'=>'image'],
+    ], JSON_PRETTY_PRINT);
+  }
+
+  public static function menu() {
+    add_submenu_page('gffm', __('Vendor Portal','gffm'), __('Vendor Portal','gffm'), 'gffm_manage', 'gffm_vendor_portal', [__CLASS__,'render_settings']);
+  }
+
+  public static function register_settings() {
+    register_setting('gffm_vendor_portal', 'gffm_week_start_day', [
+      'type' => 'string',
+      'sanitize_callback' => function($v){ $valid=['monday','tuesday','wednesday','thursday','friday','saturday','sunday']; $v=strtolower($v); return in_array($v,$valid,true)?$v:'saturday'; },
+      'default' => 'saturday',
+    ]);
+    register_setting('gffm_vendor_portal', 'gffm_profile_map_json', [
+      'type' => 'string',
+      'sanitize_callback' => function($v){ return wp_kses_post($v); },
+      'default' => self::default_mapping(),
+    ]);
+    register_setting('gffm_vendor_portal', 'gffm_invite_subject', [
+      'type'=>'string',
+      'sanitize_callback'=>'sanitize_text_field',
+      'default'=>'Your Vendor Portal Link – {site_name}',
+    ]);
+    register_setting('gffm_vendor_portal', 'gffm_invite_body', [
+      'type'=>'string',
+      'sanitize_callback'=>'wp_kses_post',
+      'default'=>"Hello {vendor_title},\n\nYour one-click sign-in link:\n{portal_url}\n\nThis link will expire in 24 hours.\n– {site_name}",
+    ]);
+  }
+
+  public static function render_settings() {
+    if ( ! current_user_can('gffm_manage') ) wp_die(__('You do not have permission.','gffm'));
+    echo '<div class="wrap"><h1>'.esc_html__('Vendor Portal','gffm').'</h1>';
+    echo '<form method="post" action="options.php">';
+    settings_fields('gffm_vendor_portal');
+    echo '<table class="form-table" role="presentation">';
+    $day = get_option('gffm_week_start_day','saturday');
+    echo '<tr><th><label for="gffm_week_start_day">'.esc_html__('Week Starts On','gffm').'</label></th><td><select name="gffm_week_start_day" id="gffm_week_start_day">';
+    foreach(['monday','tuesday','wednesday','thursday','friday','saturday','sunday'] as $d){
+      echo '<option value="'.esc_attr($d).'" '.selected($day,$d,false).'>'.esc_html(ucfirst($d)).'</option>';
+    }
+    echo '</select></td></tr>';
+    echo '<tr><th><label for="gffm_profile_map_json">'.esc_html__('Profile Field Mapping (JSON)','gffm').'</label></th>';
+    echo '<td><textarea name="gffm_profile_map_json" id="gffm_profile_map_json" rows="10" cols="50" class="large-text code">'.esc_textarea(get_option('gffm_profile_map_json', self::default_mapping())).'</textarea></td></tr>';
+    echo '<tr><th><label for="gffm_invite_subject">'.esc_html__('Invite Email Subject','gffm').'</label></th>';
+    echo '<td><input type="text" name="gffm_invite_subject" id="gffm_invite_subject" class="regular-text" value="'.esc_attr(get_option('gffm_invite_subject','Your Vendor Portal Link – {site_name}')).'"/></td></tr>';
+    echo '<tr><th><label for="gffm_invite_body">'.esc_html__('Invite Email Body','gffm').'</label></th>';
+    echo '<td><textarea name="gffm_invite_body" id="gffm_invite_body" rows="6" cols="50" class="large-text code">'.esc_textarea(get_option('gffm_invite_body',"Hello {vendor_title},\n\nYour one-click sign-in link:\n{portal_url}\n\nThis link will expire in 24 hours.\n– {site_name}")).'</textarea><p class="description">'.esc_html__('Placeholders: {site_name}, {vendor_title}, {portal_url}','gffm').'</p></td></tr>';
+    echo '</table>';
+    submit_button();
+    echo '</form></div>';
+  }
+
+  public static function shortcode($atts, $content = '') {
+    if ( ! is_user_logged_in() ) {
+      return '<p>'.esc_html__('Please check your email for a magic link to access the vendor portal.','gffm').'</p>';
+    }
+    $vendor_id = GFFM_Util::current_user_vendor_id();
+    if ( ! $vendor_id ) {
+      return '<p>'.esc_html__('Your account is not linked to a vendor.','gffm').'</p>';
+    }
+    if ( ! GFFM_Util::can_edit_vendor($vendor_id) ) {
+      return '<p>'.esc_html__('You do not have permission to access this vendor.','gffm').'</p>';
+    }
+    wp_enqueue_style('gffm-portal', GFFM_URL.'assets/portal.css', [], GFFM_VERSION);
+    wp_enqueue_script('gffm-portal', GFFM_URL.'assets/portal.js', ['jquery'], GFFM_VERSION, true);
+    wp_enqueue_media();
+
+    $out = '';
+    $notice = '';
+    if ( isset($_POST['gffm_profile_nonce']) && wp_verify_nonce($_POST['gffm_profile_nonce'],'gffm_profile_save') ) {
+      $notice = self::handle_profile_save($vendor_id);
+    }
+    if ( isset($_POST['gffm_highlight_nonce']) && wp_verify_nonce($_POST['gffm_highlight_nonce'],'gffm_highlight_save') ) {
+      $notice = self::handle_highlight_save($vendor_id);
+    }
+
+    if ( $notice ) {
+      $out .= '<div class="gffm-notice">'.esc_html($notice).'</div>';
+    }
+
+    $map = json_decode(get_option('gffm_profile_map_json', self::default_mapping()), true);
+    if ( ! is_array($map) ) $map = [];
+
+    $out .= '<div class="gffm-portal-tabs">';
+    $out .= '<ul class="gffm-tab-nav"><li class="active" data-tab="profile">'.esc_html__('Profile','gffm').'</li><li data-tab="highlight">'.esc_html__('Weekly Highlight','gffm').'</li></ul>';
+    $out .= '<div class="gffm-tab-content active" id="gffm-tab-profile">';
+    $out .= '<form method="post">';
+    wp_nonce_field('gffm_profile_save','gffm_profile_nonce');
+    foreach ($map as $key => $field) {
+      $type = $field['type'] ?? 'text';
+      $label = $field['label'] ?? $key;
+      $value = get_post_meta($vendor_id, $key, true);
+      $out .= '<p><label>'.esc_html($label).'<br/>';
+      if ( 'textarea' === $type ) {
+        $out .= '<textarea name="pf['.esc_attr($key).']" class="widefat">'.esc_textarea($value).'</textarea>';
+      } elseif ( 'image' === $type ) {
+        $img = $value ? wp_get_attachment_image($value, 'thumbnail') : '';
+        $out .= '<input type="hidden" name="pf['.esc_attr($key).']" value="'.esc_attr($value).'" class="gffm-img-field" />';
+        $out .= '<span class="gffm-img-preview">'.$img.'</span><button type="button" class="button gffm-img-btn" data-target="pf['.esc_attr($key).']">'.esc_html__('Choose Image','gffm').'</button>';
+      } else {
+        $out .= '<input type="'.esc_attr($type).'" name="pf['.esc_attr($key).']" value="'.esc_attr($value).'" class="widefat"/>';
+      }
+      $out .= '</label></p>';
+    }
+    $out .= '<p><button class="button button-primary">'.esc_html__('Save Profile','gffm').'</button></p>';
+    $out .= '</form></div>'; // profile tab
+
+    // Highlight tab
+    $week_key = GFFM_Util::week_key();
+    $current = get_posts([
+      'post_type' => 'gffm_highlight',
+      'author' => get_current_user_id(),
+      'meta_key' => '_gffm_week_key',
+      'meta_value' => $week_key,
+      'post_status' => ['draft','publish'],
+      'posts_per_page' => 1,
+    ]);
+    $highlight = $current ? $current[0] : null;
+    $title = $highlight ? $highlight->post_title : '';
+    $content = $highlight ? $highlight->post_content : '';
+    $image_id = $highlight ? get_post_thumbnail_id($highlight->ID) : 0;
+
+    $out .= '<div class="gffm-tab-content" id="gffm-tab-highlight">';
+    $out .= '<form method="post">';
+    wp_nonce_field('gffm_highlight_save','gffm_highlight_nonce');
+    $out .= '<p><label>'.esc_html__('Headline','gffm').'<br/><input type="text" name="hl_title" class="widefat" value="'.esc_attr($title).'"/></label></p>';
+    $out .= '<p><label>'.esc_html__('Details','gffm').'<br/><textarea name="hl_content" class="widefat">'.esc_textarea($content).'</textarea></label></p>';
+    $out .= '<p><label>'.esc_html__('Image','gffm').'<br/><input type="hidden" name="hl_image" value="'.esc_attr($image_id).'" class="gffm-img-field" /><span class="gffm-img-preview">'.($image_id ? wp_get_attachment_image($image_id,'thumbnail') : '').'</span><button type="button" class="button gffm-img-btn" data-target="hl_image">'.esc_html__('Choose Image','gffm').'</button></label></p>';
+    $out .= '<p><button class="button button-primary">'.esc_html__('Save Highlight','gffm').'</button></p>';
+    $out .= '</form></div>'; // highlight tab
+
+    $out .= '</div>'; // tabs wrapper
+    return $out;
+  }
+
+  private static function handle_profile_save(int $vendor_id): string {
+    if ( ! GFFM_Util::can_edit_vendor($vendor_id) ) {
+      return __('Permission denied.','gffm');
+    }
+    $map = json_decode(get_option('gffm_profile_map_json', self::default_mapping()), true);
+    $fields = isset($_POST['pf']) && is_array($_POST['pf']) ? $_POST['pf'] : [];
+    foreach ($fields as $key => $val) {
+      if ( ! isset($map[$key]) ) continue;
+      $type = $map[$key]['type'] ?? 'text';
+      if ( 'textarea' === $type ) {
+        $clean = wp_kses_post($val);
+      } elseif ( 'email' === $type ) {
+        $clean = sanitize_email($val);
+      } elseif ( 'url' === $type ) {
+        $clean = esc_url_raw($val);
+      } elseif ( 'image' === $type ) {
+        $clean = absint($val);
+      } else {
+        $clean = sanitize_text_field($val);
+      }
+      update_post_meta($vendor_id, $key, $clean);
+    }
+    return __('Profile saved.','gffm');
+  }
+
+  private static function handle_highlight_save(int $vendor_id): string {
+    if ( ! GFFM_Util::can_edit_vendor($vendor_id) ) {
+      return __('Permission denied.','gffm');
+    }
+    $title = isset($_POST['hl_title']) ? sanitize_text_field(wp_unslash($_POST['hl_title'])) : '';
+    $content = isset($_POST['hl_content']) ? wp_kses_post(wp_unslash($_POST['hl_content'])) : '';
+    $image = isset($_POST['hl_image']) ? absint($_POST['hl_image']) : 0;
+    $week_key = GFFM_Util::week_key();
+    $existing = get_posts([
+      'post_type' => 'gffm_highlight',
+      'author' => get_current_user_id(),
+      'meta_key' => '_gffm_week_key',
+      'meta_value' => $week_key,
+      'post_status' => ['draft','publish'],
+      'posts_per_page' => 1,
+    ]);
+    if ( $existing ) {
+      $post_id = $existing[0]->ID;
+      wp_update_post(['ID'=>$post_id,'post_title'=>$title,'post_content'=>$content]);
+    } else {
+      $post_id = wp_insert_post([
+        'post_type'=>'gffm_highlight',
+        'post_title'=>$title,
+        'post_content'=>$content,
+        'post_status'=>'publish',
+        'post_author'=>get_current_user_id(),
+      ]);
+    }
+    if ( ! is_wp_error($post_id) ) {
+      update_post_meta($post_id, '_gffm_week_key', $week_key);
+      if ( $image ) {
+        set_post_thumbnail($post_id, $image);
+      }
+    }
+    return __('Highlight saved.','gffm');
+  }
+}
+GFFM_Portal::init();

--- a/includes/portal/class-gffm-vendor-link.php
+++ b/includes/portal/class-gffm-vendor-link.php
@@ -1,0 +1,103 @@
+<?php
+defined('ABSPATH') || exit;
+
+class GFFM_Vendor_Link {
+  public static function init() {
+    add_action('add_meta_boxes', [__CLASS__, 'meta_box']);
+    add_action('save_post', [__CLASS__, 'save_meta']);
+    add_action('admin_post_gffm_invite_vendor', [__CLASS__, 'handle_invite']);
+    add_action('admin_notices', [__CLASS__, 'admin_notices']);
+  }
+
+  public static function vendor_cpt(): string {
+    return get_option('gffm_use_internal_vendors', 'no') === 'yes' ? 'gffm_vendor' : 'vendor';
+  }
+
+  public static function meta_box() {
+    add_meta_box('gffm_vendor_portal', __('Vendor Portal Access','gffm'), [__CLASS__,'render_meta'], self::vendor_cpt(), 'side');
+  }
+
+  public static function render_meta($post) {
+    $enabled = get_post_meta($post->ID, '_gffm_portal_enabled', true) === '1';
+    $linked  = (int) get_post_meta($post->ID, '_gffm_linked_user', true);
+    $user    = $linked ? get_userdata($linked) : false;
+    wp_nonce_field('gffm_vendor_portal','gffm_vendor_portal_nonce');
+    echo '<p><label><input type="checkbox" name="gffm_portal_enabled" value="1" '.checked($enabled,true,false).' /> '.esc_html__('Enable portal access','gffm').'</label></p>';
+    echo '<p>'.esc_html__('Linked user:','gffm').' '.($user ? esc_html($user->user_email) : '&mdash;').'</p>';
+    echo '<hr/>'; 
+    echo '<p><strong>'.esc_html__('Send Magic Link','gffm').'</strong></p>';
+    echo '<form method="post" action="'.esc_url(admin_url('admin-post.php')).'">';
+    echo '<input type="hidden" name="action" value="gffm_invite_vendor"/>';
+    echo '<input type="hidden" name="vendor_id" value="'.absint($post->ID).'"/>';
+    wp_nonce_field('gffm_invite_vendor','gffm_invite_nonce');
+    echo '<p><input type="email" required name="gffm_invite_email" class="widefat" placeholder="'.esc_attr__('vendor@example.com','gffm').'"/></p>';
+    echo '<p><button class="button">'.esc_html__('Send Invite','gffm').'</button></p>';
+    echo '</form>';
+  }
+
+  public static function save_meta($post_id) {
+    if ( ! isset($_POST['gffm_vendor_portal_nonce']) || ! wp_verify_nonce($_POST['gffm_vendor_portal_nonce'],'gffm_vendor_portal') ) {
+      return;
+    }
+    if ( defined('DOING_AUTOSAVE') && DOING_AUTOSAVE ) return;
+    if ( ! current_user_can('edit_post', $post_id) ) return;
+    $enabled = isset($_POST['gffm_portal_enabled']) ? '1' : '';
+    update_post_meta($post_id, '_gffm_portal_enabled', $enabled);
+  }
+
+  public static function handle_invite() {
+    if ( ! current_user_can('manage_options') && ! current_user_can('gffm_manage') ) {
+      wp_die(__('You do not have permission.','gffm'));
+    }
+    if ( ! isset($_POST['gffm_invite_nonce']) || ! wp_verify_nonce($_POST['gffm_invite_nonce'],'gffm_invite_vendor') ) {
+      wp_die(__('Invalid nonce.','gffm'));
+    }
+    $vendor_id = isset($_POST['vendor_id']) ? absint($_POST['vendor_id']) : 0;
+    $email = isset($_POST['gffm_invite_email']) ? sanitize_email(wp_unslash($_POST['gffm_invite_email'])) : '';
+    if ( ! $vendor_id || ! $email ) {
+      wp_safe_redirect( wp_get_referer() );
+      exit;
+    }
+    $user = get_user_by('email', $email);
+    if ( ! $user ) {
+      $pwd = wp_generate_password(12, false);
+      $uid = wp_create_user($email, $pwd, $email);
+      if ( is_wp_error($uid) ) {
+        wp_safe_redirect( add_query_arg('gffm_invite','fail', wp_get_referer()) );
+        exit;
+      }
+      $user = get_user_by('id', $uid);
+    }
+    $user_id = $user->ID;
+    $user->set_role('gffm_vendor');
+    update_user_meta($user_id, '_gffm_vendor_id', $vendor_id);
+    update_post_meta($vendor_id, '_gffm_linked_user', $user_id);
+    update_post_meta($vendor_id, '_gffm_portal_enabled', '1');
+
+    $token = GFFM_Magic::issue_token($user_id);
+    $portal_url = home_url('/vendor-portal/') . '?gffm_magic=' . rawurlencode($token);
+    $subject = get_option('gffm_invite_subject', 'Your Vendor Portal Link – {site_name}');
+    $body    = get_option('gffm_invite_body', "Hello {vendor_title},\n\nYour one-click sign-in link:\n{portal_url}\n\nThis link will expire in 24 hours.\n– {site_name}");
+    $vendor_title = get_the_title($vendor_id);
+    $repl = [
+      '{site_name}'    => get_bloginfo('name'),
+      '{vendor_title}' => $vendor_title,
+      '{portal_url}'   => $portal_url,
+    ];
+    $subject = strtr($subject, $repl);
+    $body    = strtr($body, $repl);
+    wp_mail($email, $subject, $body);
+
+    wp_safe_redirect( add_query_arg('gffm_invite','sent', wp_get_referer()) );
+    exit;
+  }
+
+  public static function admin_notices() {
+    if ( isset($_GET['gffm_invite']) && $_GET['gffm_invite'] === 'sent' ) {
+      echo '<div class="notice notice-success"><p>'.esc_html__('Invitation email sent.','gffm').'</p></div>';
+    } elseif ( isset($_GET['gffm_invite']) && $_GET['gffm_invite'] === 'fail' ) {
+      echo '<div class="notice notice-error"><p>'.esc_html__('Failed to create or retrieve user.','gffm').'</p></div>';
+    }
+  }
+}
+GFFM_Vendor_Link::init();

--- a/uninstall.php
+++ b/uninstall.php
@@ -3,3 +3,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) { die; }
 delete_option('gffm_notification_email');
 delete_option('gffm_use_internal_vendors');
 delete_option('gffm_max_vendors');
+delete_option('gffm_week_start_day');
+delete_option('gffm_profile_map_json');
+delete_option('gffm_invite_subject');
+delete_option('gffm_invite_body');


### PR DESCRIPTION
## Summary
- add vendor portal with magic-link authentication, profile mapping, and weekly highlight editor
- introduce `gffm_highlight` post type and `[gffm_this_week]` shortcode
- ensure `gffm_vendor` role and portal settings with invite templates
- document portal behaviour and test plan

## Testing
- `php -l includes/helpers/class-gffm-util.php`
- `php -l includes/portal/class-gffm-magic.php`
- `php -l includes/portal/class-gffm-vendor-link.php`
- `php -l includes/portal/class-gffm-portal.php`
- `php -l includes/highlights/class-gffm-highlights.php`
- `php -l includes/class-gffm-roles.php`
- `php -l gffm-market-manager-unified.php`
- `php -l includes/class-gffm-settings.php`
- `php -l uninstall.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8855c6ec08322b8f2bf75e46f6646