### PR TITLE
feat: add vendor enable/disable toggle

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+4.1.1 — Vendor Assignment Toggle
+- Added enable/disable toggle links on the Vendor Assignment page.
+
 4.1.0 — Vendor Portal Integration & Weekly Highlights
 - Added vendor magic-link authentication and portal dashboard.
 - Introduced `gffm_highlight` CPT and `[gffm_this_week]` shortcode.

--- a/TESTPLAN.md
+++ b/TESTPLAN.md
@@ -10,4 +10,5 @@
    - Update profile fields and confirm post meta saves.
    - Submit a weekly highlight and ensure only one post per week.
 6. Place `[gffm_this_week]` on a page and confirm highlights appear.
-7. Uninstall plugin and confirm portal options are removed but posts remain.
+7. From **Vendor Assignment**, toggle a vendor's enable state and confirm the table reflects the change.
+8. Uninstall plugin and confirm portal options are removed but posts remain.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -3,3 +3,4 @@
 - Magic link authentication selected with HMAC tokens expiring after 24 hours.
 - Profile editing writes directly to Smart Custom Fields post meta to maintain compatibility.
 - Weekly highlights grouped by configurable week start day (default Saturday).
+- Vendors can be enabled or disabled from the assignment table; disabling removes the `_gffm_enabled` flag.

--- a/includes/class-gffm-admin.php
+++ b/includes/class-gffm-admin.php
@@ -5,13 +5,40 @@ class GFFM_Admin {
     public static function render_assignment(){
         if( ! current_user_can('gffm_manage')) wp_die(__('You do not have permission.','gffm'));
         $nonce_action = 'gffm_assign_vendors';
-        // Handle POST
+
+        // Handle toggle requests
+        if( isset($_GET['gffm_toggle_vendor']) ){
+            $vid = absint($_GET['gffm_toggle_vendor']);
+            if( check_admin_referer('gffm_toggle_vendor_'.$vid) ){
+                $enabled = get_post_meta($vid, '_gffm_enabled', true) === '1';
+                if( $enabled ){
+                    delete_post_meta($vid, '_gffm_enabled');
+                    $msg = 'disabled';
+                } else {
+                    update_post_meta($vid, '_gffm_enabled', '1');
+                    $msg = 'enabled';
+                }
+                wp_safe_redirect( add_query_arg('gffm_msg', $msg, admin_url('admin.php?page=gffm_assignment')) );
+                exit;
+            }
+        }
+
+        // Handle bulk enable
         if( isset($_POST['gffm_assign_submit']) && check_admin_referer($nonce_action) ){
             $ids = isset($_POST['gffm_vendor_ids']) ? array_map('absint', (array)$_POST['gffm_vendor_ids']) : [];
             foreach($ids as $vid){
                 update_post_meta($vid, '_gffm_enabled', '1');
             }
             echo '<div class="updated"><p>'.sprintf(esc_html__('%d vendors enabled for GFFM.','gffm'), count($ids)).'</p></div>';
+        }
+
+        if( isset($_GET['gffm_msg']) ){
+            $msg = sanitize_key($_GET['gffm_msg']);
+            if( $msg === 'enabled' ){
+                echo '<div class="updated"><p>'.esc_html__('Vendor enabled for GFFM.','gffm').'</p></div>';
+            } elseif( $msg === 'disabled' ){
+                echo '<div class="updated"><p>'.esc_html__('Vendor disabled for GFFM.','gffm').'</p></div>';
+            }
         }
 
         // detect CPT to read from
@@ -33,11 +60,18 @@ class GFFM_Admin {
         echo '<table class="widefat striped"><thead><tr><th></th><th>'.esc_html__('Vendor','gffm').'</th><th>'.esc_html__('Status','gffm').'</th><th>'.esc_html__('Assigned?','gffm').'</th></tr></thead><tbody>';
         foreach($vendors as $v){
             $enabled = get_post_meta($v->ID, '_gffm_enabled', true) === '1';
+            $toggle_url = wp_nonce_url( add_query_arg('gffm_toggle_vendor', $v->ID, admin_url('admin.php?page=gffm_assignment')), 'gffm_toggle_vendor_'.$v->ID );
             echo '<tr>';
             echo '<td><input type="checkbox" name="gffm_vendor_ids[]" value="'.esc_attr($v->ID).'" data-gffm-row="1"/></td>';
             echo '<td><a href="'.get_edit_post_link($v->ID).'">'.esc_html(get_the_title($v->ID)).'</a></td>';
             echo '<td>'.esc_html($v->post_status).'</td>';
-            echo '<td>'.($enabled?'<span class="dashicons dashicons-yes"></span>':'&mdash;').'</td>';
+            echo '<td>';
+            if( $enabled ){
+                echo '<span class="dashicons dashicons-yes"></span> <a href="'.esc_url($toggle_url).'">'.esc_html__('Disable','gffm').'</a>';
+            } else {
+                echo '&mdash; <a href="'.esc_url($toggle_url).'">'.esc_html__('Enable','gffm').'</a>';
+            }
+            echo '</td>';
             echo '</tr>';
         }
         echo '</tbody></table>';


### PR DESCRIPTION
## Summary
- add toggle links on Vendor Assignment page to enable or disable vendors
- document new toggle in decisions and changelog
- update test plan with toggle scenario

## Testing
- `php -l includes/class-gffm-admin.php`
- `php -l gffm-market-manager-unified.php`


------
https://chatgpt.com/codex/tasks/task_e_68a899363cc483228f671db7981bc69b